### PR TITLE
There are more than 3 OS in the world...

### DIFF
--- a/src/lin.rs
+++ b/src/lin.rs
@@ -1,5 +1,3 @@
-#![cfg(not(any(target_os = "windows", target_os = "macos")))]
-
 use std::env;
 use std::ffi::OsString;
 use std::path::PathBuf;

--- a/src/lin.rs
+++ b/src/lin.rs
@@ -1,4 +1,4 @@
-#![cfg(target_os = "linux")]
+#![cfg(not(any(target_os = "windows", target_os = "macos")))]
 
 use std::env;
 use std::ffi::OsString;

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -1,5 +1,3 @@
-#![cfg(target_os = "macos")]
-
 use std::path::PathBuf;
 
 use unix;

--- a/src/win.rs
+++ b/src/win.rs
@@ -1,5 +1,3 @@
-#![cfg(target_os = "windows")]
-
 use std;
 use std::path::PathBuf;
 


### PR DESCRIPTION
On anything other than Windows/macOS/Linux this fails to build because `lib.rs` suggests using `lin.rs`, while `lib.rs` doesn't exist for anything other than Linux. 

tl;dr: fixes freebsd and other bsd builds.

Cheers.