### PR TITLE
Bump version to 1.0.3.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name        = "dirs"
-version     = "1.0.2"
+version     = "1.0.3"
 authors     = ["Simon Ochsenreither <simon@ochsenreither.de>"]
 description = "A tiny low-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS."
 readme      = "README.md"


### PR DESCRIPTION
Now that dirs-rs runs on non-{Linux,macOS,Windows} platforms, a version
bump will help other crates incorporate these changes.