### PR TITLE
Add support to retrieve default applications directory

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name        = "dirs"
-version     = "1.0.4"
-authors     = ["Simon Ochsenreither <simon@ochsenreither.de>"]
+name        = "dirs-2"
+version     = "1.1.0"
+authors     = ["Manfred Endres <manfred.endres@tslarusso.de", "Simon Ochsenreither <simon@ochsenreither.de>"]
 description = "A tiny low-level library that provides platform-specific standard locations of directories for config, cache and other data on Linux, Windows and macOS by leveraging the mechanisms defined by the XDG base/user directory specifications on Linux, the Known Folder API on Windows, and the Standard Directory guidelines on macOS."
 readme      = "README.md"
 license     = "MIT OR Apache-2.0"
-repository  = "https://github.com/soc/dirs-rs"
+repository  = "https://github.com/Larusso/dirs-rs"
 maintenance = { status = "actively-developed" }
 keywords    = ["xdg", "basedir", "app_dirs", "path", "folder"]
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,7 +50,7 @@ use std::path::PathBuf;
 /// This function retrieves the user profile folder using `SHGetKnownFolderPath`.
 ///
 /// All the examples on this page mentioning `$HOME` use this behavior.
-/// 
+///
 /// _Note:_ This function's behavior differs from [`std::env::home_dir`],
 /// which works incorrectly on Linux, macOS and Windows.
 ///
@@ -59,8 +59,8 @@ pub fn home_dir() -> Option<PathBuf> {
     sys::home_dir()
 }
 /// Returns the path to the user's cache directory.
-/// 
-/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
 ///
 /// |Platform | Value                               | Example                      |
 /// | ------- | ----------------------------------- | ---------------------------- |
@@ -72,7 +72,7 @@ pub fn cache_dir() -> Option<PathBuf> {
 }
 /// Returns the path to the user's config directory.
 ///
-/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
 ///
 /// |Platform | Value                                 | Example                          |
 /// | ------- | ------------------------------------- | -------------------------------- |
@@ -84,7 +84,7 @@ pub fn config_dir() -> Option<PathBuf> {
 }
 /// Returns the path to the user's data directory.
 ///
-/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
 ///
 /// |Platform | Value                                    | Example                                  |
 /// | ------- | ---------------------------------------- | ---------------------------------------- |
@@ -96,7 +96,7 @@ pub fn data_dir() -> Option<PathBuf> {
 }
 /// Returns the path to the user's local data directory.
 ///
-/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
 ///
 /// |Platform | Value                                    | Example                                  |
 /// | ------- | ---------------------------------------- | ---------------------------------------- |
@@ -108,7 +108,7 @@ pub fn data_local_dir() -> Option<PathBuf> {
 }
 /// Returns the path to the user's executable directory.
 ///
-/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
 ///
 /// |Platform | Value                                                            | Example                |
 /// | ------- | ---------------------------------------------------------------- | ---------------------- |
@@ -118,9 +118,21 @@ pub fn data_local_dir() -> Option<PathBuf> {
 pub fn executable_dir() -> Option<PathBuf> {
     sys::executable_dir()
 }
+/// Returns the path to the applications directory.
+///
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
+///
+/// |Platform | Value                     | Example         |
+/// | ------- | ------------------------- | --------------- |
+/// | Linux   | -                         | -               |
+/// | macOS   | `/Applications`           | –               |
+/// | Windows | `{FOLDERID_ProgramFiles}` | –               |
+pub fn application_dir() -> Option<PathBuf> {
+    sys::application_dir()
+}
 /// Returns the path to the user's runtime directory.
 ///
-/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
 ///
 /// |Platform | Value              | Example         |
 /// | ------- | ------------------ | --------------- |
@@ -133,7 +145,7 @@ pub fn runtime_dir() -> Option<PathBuf> {
 
 /// Returns the path to the user's audio directory.
 ///
-/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
 ///
 /// |Platform | Value              | Example              |
 /// | ------- | ------------------ | -------------------- |
@@ -145,7 +157,7 @@ pub fn audio_dir() -> Option<PathBuf> {
 }
 /// Returns the path to the user's desktop directory.
 ///
-/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
 ///
 /// |Platform | Value                | Example                |
 /// | ------- | -------------------- | ---------------------- |
@@ -157,7 +169,7 @@ pub fn desktop_dir() -> Option<PathBuf> {
 }
 /// Returns the path to the user's document directory.
 ///
-/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
 ///
 /// |Platform | Value                  | Example                  |
 /// | ------- | ---------------------- | ------------------------ |
@@ -169,7 +181,7 @@ pub fn document_dir() -> Option<PathBuf> {
 }
 /// Returns the path to the user's download directory.
 ///
-/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
 ///
 /// |Platform | Value                  | Example                  |
 /// | ------- | ---------------------- | ------------------------ |
@@ -181,7 +193,7 @@ pub fn download_dir() -> Option<PathBuf> {
 }
 /// Returns the path to the user's font directory.
 ///
-/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
 ///
 /// |Platform | Value                                                | Example                        |
 /// | ------- | ---------------------------------------------------- | ------------------------------ |
@@ -193,7 +205,7 @@ pub fn font_dir() -> Option<PathBuf> {
 }
 /// Returns the path to the user's picture directory.
 ///
-/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
 ///
 /// |Platform | Value                 | Example                 |
 /// | ------- | --------------------- | ----------------------- |
@@ -205,7 +217,7 @@ pub fn picture_dir() -> Option<PathBuf> {
 }
 /// Returns the path to the user's public directory.
 ///
-/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
 ///
 /// |Platform | Value                 | Example             |
 /// | ------- | --------------------- | ------------------- |
@@ -217,7 +229,7 @@ pub fn public_dir() -> Option<PathBuf> {
 }
 /// Returns the path to the user's template directory.
 ///
-/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
 ///
 /// |Platform | Value                  | Example                                                    |
 /// | ------- | ---------------------- | ---------------------------------------------------------- |
@@ -230,7 +242,7 @@ pub fn template_dir() -> Option<PathBuf> {
 
 /// Returns the path to the user's video directory.
 ///
-/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None.
+/// The returned value depends on the operating system and is either a `Some`, containing a value from the following table, or a `None`.
 ///
 /// |Platform | Value               | Example               |
 /// | ------- | ------------------- | --------------------- |
@@ -246,21 +258,22 @@ pub fn video_dir() -> Option<PathBuf> {
 mod tests {
     #[test]
     fn test_dirs() {
-        println!("home_dir:       {:?}", ::home_dir());
-        println!("cache_dir:      {:?}", ::cache_dir());
-        println!("config_dir:     {:?}", ::config_dir());
-        println!("data_dir:       {:?}", ::data_dir());
-        println!("data_local_dir: {:?}", ::data_local_dir());
-        println!("executable_dir: {:?}", ::executable_dir());
-        println!("runtime_dir:    {:?}", ::runtime_dir());
-        println!("audio_dir:      {:?}", ::audio_dir());
-        println!("home_dir:       {:?}", ::desktop_dir());
-        println!("cache_dir:      {:?}", ::document_dir());
-        println!("config_dir:     {:?}", ::download_dir());
-        println!("font_dir:       {:?}", ::font_dir());
-        println!("picture_dir:    {:?}", ::picture_dir());
-        println!("public_dir:     {:?}", ::public_dir());
-        println!("template_dir:   {:?}", ::template_dir());
-        println!("video_dir:      {:?}", ::video_dir());
+        println!("home_dir:        {:?}", ::home_dir());
+        println!("cache_dir:       {:?}", ::cache_dir());
+        println!("config_dir:      {:?}", ::config_dir());
+        println!("data_dir:        {:?}", ::data_dir());
+        println!("data_local_dir:  {:?}", ::data_local_dir());
+        println!("executable_dir:  {:?}", ::executable_dir());
+        println!("application_dir: {:?}", ::application_dir());
+        println!("runtime_dir:     {:?}", ::runtime_dir());
+        println!("audio_dir:       {:?}", ::audio_dir());
+        println!("home_dir:        {:?}", ::desktop_dir());
+        println!("cache_dir:       {:?}", ::document_dir());
+        println!("config_dir:      {:?}", ::download_dir());
+        println!("font_dir:        {:?}", ::font_dir());
+        println!("picture_dir:     {:?}", ::picture_dir());
+        println!("public_dir:      {:?}", ::public_dir());
+        println!("template_dir:    {:?}", ::template_dir());
+        println!("video_dir:       {:?}", ::video_dir());
     }
 }

--- a/src/lin.rs
+++ b/src/lin.rs
@@ -5,26 +5,27 @@ use std::process::Command;
 
 use unix;
 
-pub fn home_dir()       -> Option<PathBuf> { unix::home_dir() }
-pub fn cache_dir()      -> Option<PathBuf> { env::var_os("XDG_CACHE_HOME") .and_then(is_absolute_path).or_else(|| home_dir().map(|h| h.join(".cache"))) }
-pub fn config_dir()     -> Option<PathBuf> { env::var_os("XDG_CONFIG_HOME").and_then(is_absolute_path).or_else(|| home_dir().map(|h| h.join(".config"))) }
-pub fn data_dir()       -> Option<PathBuf> { env::var_os("XDG_DATA_HOME")  .and_then(is_absolute_path).or_else(|| home_dir().map(|h| h.join(".local/share"))) }
-pub fn data_local_dir() -> Option<PathBuf> { data_dir().clone() }
-pub fn runtime_dir()    -> Option<PathBuf> { env::var_os("XDG_RUNTIME_DIR").and_then(is_absolute_path) }
-pub fn executable_dir() -> Option<PathBuf> {
+pub fn home_dir()        -> Option<PathBuf> { unix::home_dir() }
+pub fn cache_dir()       -> Option<PathBuf> { env::var_os("XDG_CACHE_HOME") .and_then(is_absolute_path).or_else(|| home_dir().map(|h| h.join(".cache"))) }
+pub fn config_dir()      -> Option<PathBuf> { env::var_os("XDG_CONFIG_HOME").and_then(is_absolute_path).or_else(|| home_dir().map(|h| h.join(".config"))) }
+pub fn data_dir()        -> Option<PathBuf> { env::var_os("XDG_DATA_HOME")  .and_then(is_absolute_path).or_else(|| home_dir().map(|h| h.join(".local/share"))) }
+pub fn data_local_dir()  -> Option<PathBuf> { data_dir().clone() }
+pub fn runtime_dir()     -> Option<PathBuf> { env::var_os("XDG_RUNTIME_DIR").and_then(is_absolute_path) }
+pub fn executable_dir()  -> Option<PathBuf> {
     env::var_os("XDG_BIN_HOME").and_then(is_absolute_path).or_else(|| {
         data_dir().map(|mut e| { e.pop(); e.push("bin"); e })
     })
 }
-pub fn audio_dir()      -> Option<PathBuf> { run_xdg_user_dir_command("MUSIC") }
-pub fn desktop_dir()    -> Option<PathBuf> { run_xdg_user_dir_command("DESKTOP") }
-pub fn document_dir()   -> Option<PathBuf> { run_xdg_user_dir_command("DOCUMENTS") }
-pub fn download_dir()   -> Option<PathBuf> { run_xdg_user_dir_command("DOWNLOAD") }
-pub fn font_dir()       -> Option<PathBuf> { data_dir().map(|d| d.join("fonts")) }
-pub fn picture_dir()    -> Option<PathBuf> { run_xdg_user_dir_command("PICTURES") }
-pub fn public_dir()     -> Option<PathBuf> { run_xdg_user_dir_command("PUBLICSHARE") }
-pub fn template_dir()   -> Option<PathBuf> { run_xdg_user_dir_command("TEMPLATES") }
-pub fn video_dir()      -> Option<PathBuf> { run_xdg_user_dir_command("VIDEOS") }
+pub fn application_dir() -> Option<PathBuf> { None }
+pub fn audio_dir()       -> Option<PathBuf> { run_xdg_user_dir_command("MUSIC") }
+pub fn desktop_dir()     -> Option<PathBuf> { run_xdg_user_dir_command("DESKTOP") }
+pub fn document_dir()    -> Option<PathBuf> { run_xdg_user_dir_command("DOCUMENTS") }
+pub fn download_dir()    -> Option<PathBuf> { run_xdg_user_dir_command("DOWNLOAD") }
+pub fn font_dir()        -> Option<PathBuf> { data_dir().map(|d| d.join("fonts")) }
+pub fn picture_dir()     -> Option<PathBuf> { run_xdg_user_dir_command("PICTURES") }
+pub fn public_dir()      -> Option<PathBuf> { run_xdg_user_dir_command("PUBLICSHARE") }
+pub fn template_dir()    -> Option<PathBuf> { run_xdg_user_dir_command("TEMPLATES") }
+pub fn video_dir()       -> Option<PathBuf> { run_xdg_user_dir_command("VIDEOS") }
 
 // we don't need to explicitly handle empty strings in the code above,
 // because an empty string is not considered to be a absolute path here.

--- a/src/mac.rs
+++ b/src/mac.rs
@@ -1,20 +1,21 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use unix;
 
-pub fn home_dir()       -> Option<PathBuf> { unix::home_dir() }
-pub fn cache_dir()      -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Caches")) }
-pub fn config_dir()     -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Preferences")) }
-pub fn data_dir()       -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Application Support")) }
-pub fn data_local_dir() -> Option<PathBuf> { data_dir() }
-pub fn executable_dir() -> Option<PathBuf> { None }
-pub fn runtime_dir()    -> Option<PathBuf> { None }
-pub fn audio_dir()      -> Option<PathBuf> { home_dir().map(|h| h.join("Music")) }
-pub fn desktop_dir()    -> Option<PathBuf> { home_dir().map(|h| h.join("Desktop")) }
-pub fn document_dir()   -> Option<PathBuf> { home_dir().map(|h| h.join("Documents")) }
-pub fn download_dir()   -> Option<PathBuf> { home_dir().map(|h| h.join("Downloads")) }
-pub fn font_dir()       -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Fonts")) }
-pub fn picture_dir()    -> Option<PathBuf> { home_dir().map(|h| h.join("Pictures")) }
-pub fn public_dir()     -> Option<PathBuf> { home_dir().map(|h| h.join("Public")) }
-pub fn template_dir()   -> Option<PathBuf> { None }
-pub fn video_dir()      -> Option<PathBuf> { home_dir().map(|h| h.join("Movies")) }
+pub fn home_dir()        -> Option<PathBuf> { unix::home_dir() }
+pub fn cache_dir()       -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Caches")) }
+pub fn config_dir()      -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Preferences")) }
+pub fn data_dir()        -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Application Support")) }
+pub fn data_local_dir()  -> Option<PathBuf> { data_dir() }
+pub fn executable_dir()  -> Option<PathBuf> { None }
+pub fn application_dir() -> Option<PathBuf> { Some(Path::new("/Applications").to_path_buf()) }
+pub fn runtime_dir()     -> Option<PathBuf> { None }
+pub fn audio_dir()       -> Option<PathBuf> { home_dir().map(|h| h.join("Music")) }
+pub fn desktop_dir()     -> Option<PathBuf> { home_dir().map(|h| h.join("Desktop")) }
+pub fn document_dir()    -> Option<PathBuf> { home_dir().map(|h| h.join("Documents")) }
+pub fn download_dir()    -> Option<PathBuf> { home_dir().map(|h| h.join("Downloads")) }
+pub fn font_dir()        -> Option<PathBuf> { home_dir().map(|h| h.join("Library/Fonts")) }
+pub fn picture_dir()     -> Option<PathBuf> { home_dir().map(|h| h.join("Pictures")) }
+pub fn public_dir()      -> Option<PathBuf> { home_dir().map(|h| h.join("Public")) }
+pub fn template_dir()    -> Option<PathBuf> { None }
+pub fn video_dir()       -> Option<PathBuf> { home_dir().map(|h| h.join("Movies")) }

--- a/src/redox.rs
+++ b/src/redox.rs
@@ -12,25 +12,26 @@ pub fn home_dir() -> Option<PathBuf> {
 
     Some(PathBuf::from(user.home.clone()))
 }
-pub fn cache_dir()      -> Option<PathBuf> { env::var_os("XDG_CACHE_HOME") .and_then(is_absolute_path).or_else(|| home_dir().map(|h| h.join(".cache"))) }
-pub fn config_dir()     -> Option<PathBuf> { env::var_os("XDG_CONFIG_HOME").and_then(is_absolute_path).or_else(|| home_dir().map(|h| h.join(".config"))) }
-pub fn data_dir()       -> Option<PathBuf> { env::var_os("XDG_DATA_HOME")  .and_then(is_absolute_path).or_else(|| home_dir().map(|h| h.join(".local/share"))) }
-pub fn data_local_dir() -> Option<PathBuf> { data_dir().clone() }
-pub fn runtime_dir()    -> Option<PathBuf> { env::var_os("XDG_RUNTIME_DIR").and_then(is_absolute_path) }
-pub fn executable_dir() -> Option<PathBuf> {
+pub fn cache_dir()       -> Option<PathBuf> { env::var_os("XDG_CACHE_HOME") .and_then(is_absolute_path).or_else(|| home_dir().map(|h| h.join(".cache"))) }
+pub fn config_dir()      -> Option<PathBuf> { env::var_os("XDG_CONFIG_HOME").and_then(is_absolute_path).or_else(|| home_dir().map(|h| h.join(".config"))) }
+pub fn data_dir()        -> Option<PathBuf> { env::var_os("XDG_DATA_HOME")  .and_then(is_absolute_path).or_else(|| home_dir().map(|h| h.join(".local/share"))) }
+pub fn data_local_dir()  -> Option<PathBuf> { data_dir().clone() }
+pub fn runtime_dir()     -> Option<PathBuf> { env::var_os("XDG_RUNTIME_DIR").and_then(is_absolute_path) }
+pub fn executable_dir()  -> Option<PathBuf> {
     env::var_os("XDG_BIN_HOME").and_then(is_absolute_path).or_else(|| {
         data_dir().map(|mut e| { e.pop(); e.push("bin"); e })
     })
 }
-pub fn audio_dir()      -> Option<PathBuf> { home_dir().map(|h| h.join("Music")) }
-pub fn desktop_dir()    -> Option<PathBuf> { home_dir().map(|h| h.join("Desktop")) }
-pub fn document_dir()   -> Option<PathBuf> { home_dir().map(|h| h.join("Documents")) }
-pub fn download_dir()   -> Option<PathBuf> { home_dir().map(|h| h.join("Downloads")) }
-pub fn font_dir()       -> Option<PathBuf> { data_dir().map(|d| d.join("fonts")) }
-pub fn picture_dir()    -> Option<PathBuf> { home_dir().map(|h| h.join("Pictures")) }
-pub fn public_dir()     -> Option<PathBuf> { home_dir().map(|h| h.join("Public")) }
-pub fn template_dir()   -> Option<PathBuf> { home_dir().map(|h| h.join("Templates")) }
-pub fn video_dir()      -> Option<PathBuf> { home_dir().map(|h| h.join("Videos")) }
+pub fn application_dir() -> Option<PathBuf> { None }
+pub fn audio_dir()       -> Option<PathBuf> { home_dir().map(|h| h.join("Music")) }
+pub fn desktop_dir()     -> Option<PathBuf> { home_dir().map(|h| h.join("Desktop")) }
+pub fn document_dir()    -> Option<PathBuf> { home_dir().map(|h| h.join("Documents")) }
+pub fn download_dir()    -> Option<PathBuf> { home_dir().map(|h| h.join("Downloads")) }
+pub fn font_dir()        -> Option<PathBuf> { data_dir().map(|d| d.join("fonts")) }
+pub fn picture_dir()     -> Option<PathBuf> { home_dir().map(|h| h.join("Pictures")) }
+pub fn public_dir()      -> Option<PathBuf> { home_dir().map(|h| h.join("Public")) }
+pub fn template_dir()    -> Option<PathBuf> { home_dir().map(|h| h.join("Templates")) }
+pub fn video_dir()       -> Option<PathBuf> { home_dir().map(|h| h.join("Videos")) }
 
 // we don't need to explicitly handle empty strings in the code above,
 // because an empty string is not considered to be a absolute path here.

--- a/src/win.rs
+++ b/src/win.rs
@@ -10,22 +10,23 @@ use self::winapi::um::shtypes;
 use self::winapi::um::winbase;
 use self::winapi::um::winnt;
 
-pub fn home_dir()       -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Profile) }
-pub fn data_dir()       -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_RoamingAppData) }
-pub fn data_local_dir() -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_LocalAppData) }
-pub fn cache_dir()      -> Option<PathBuf> { data_local_dir() }
-pub fn config_dir()     -> Option<PathBuf> { data_dir() }
-pub fn executable_dir() -> Option<PathBuf> { None }
-pub fn runtime_dir()    -> Option<PathBuf> { None }
-pub fn audio_dir()      -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Music) }
-pub fn desktop_dir()    -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Desktop) }
-pub fn document_dir()   -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Documents) }
-pub fn download_dir()   -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Downloads) }
-pub fn font_dir()       -> Option<PathBuf> { None }
-pub fn picture_dir()    -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Pictures) }
-pub fn public_dir()     -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Public) }
-pub fn template_dir()   -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Templates) }
-pub fn video_dir()      -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Videos) }
+pub fn home_dir()        -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Profile) }
+pub fn data_dir()        -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_RoamingAppData) }
+pub fn data_local_dir()  -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_LocalAppData) }
+pub fn cache_dir()       -> Option<PathBuf> { data_local_dir() }
+pub fn config_dir()      -> Option<PathBuf> { data_dir() }
+pub fn executable_dir()  -> Option<PathBuf> { None }
+pub fn application_dir() -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_ProgramFiles) }
+pub fn runtime_dir()     -> Option<PathBuf> { None }
+pub fn audio_dir()       -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Music) }
+pub fn desktop_dir()     -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Desktop) }
+pub fn document_dir()    -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Documents) }
+pub fn download_dir()    -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Downloads) }
+pub fn font_dir()        -> Option<PathBuf> { None }
+pub fn picture_dir()     -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Pictures) }
+pub fn public_dir()      -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Public) }
+pub fn template_dir()    -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Templates) }
+pub fn video_dir()       -> Option<PathBuf> { known_folder(&knownfolders::FOLDERID_Videos) }
 
 fn known_folder(folder_id: shtypes::REFKNOWNFOLDERID) -> Option<PathBuf> {
     unsafe {


### PR DESCRIPTION
## Description

Add new function `application_dir` and implement it for _windows_ and _mac os_. Windows uses `FOLDERID_ProgramFiles` to retrieve the path. On mac os the path is a hard-coded value `/Applications`

I don't know if this fits 100% because windows has multiple program files directories from the switch to 64bit. It just fits nicely in my tool :)