### PR TITLE
upgrade redox_users

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ keywords    = ["xdg", "basedir", "app_dirs", "path", "folder"]
 libc = "0.2"
 
 [target.'cfg(target_os = "redox")'.dependencies]
-redox_users = "0.2.0"
+redox_users = "0.3.0"
 
 [target.'cfg(windows)'.dependencies]
 winapi = { version = "0.3", features = ["knownfolders", "objbase", "shlobj", "winbase", "winerror"] }

--- a/src/redox.rs
+++ b/src/redox.rs
@@ -3,11 +3,13 @@ extern crate redox_users;
 use std::env;
 use std::ffi::OsString;
 use std::path::PathBuf;
+use self::redox_users::All;
 use self::redox_users::AllUsers;
+use self::redox_users::Config;
 
 pub fn home_dir() -> Option<PathBuf> {
     let current_uid = redox_users::get_uid().ok()?;
-    let users = AllUsers::new(false).ok()?;
+    let users = AllUsers::new(Config::default()).ok()?;
     let user = users.get_by_id(current_uid)?;
 
     Some(PathBuf::from(user.home.clone()))


### PR DESCRIPTION
`(false)` is `auth_required`, i.e. will we be checking `/etc/shadow`. We are not. This is the default for the `Config` constructor, i.e. not the `Config::with_auth()` constructor.

I checked it `build`s, but nothing further.