### PR TITLE
Add support for iOS

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ cfg_if! {
     if #[cfg(target_os = "windows")] {
         mod win;
         use win as sys;
-    } else if #[cfg(target_os = "macos")] {
+    } else if #[cfg(any(target_os = "macos", target_os = "ios"))] {
         mod mac;
         use mac as sys;
     } else if #[cfg(target_os = "wasi")] {


### PR DESCRIPTION
Tested on iOS, works fine. Detects the container properly so returns the correct home paths. :smile: