### PR TITLE
Remove cfg-if dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,5 +10,4 @@ maintenance = { status = "actively-developed" }
 keywords    = ["xdg", "basedir", "app_dirs", "path", "folder"]
 
 [dependencies]
-cfg-if = "0.1"
-dirs-sys = "0.3.4"
+dirs-sys = "0.3.5"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ The library provides the location of these directories by leveraging the mechani
 This library is written in Rust, and supports Linux, Redox, macOS and Windows.
 Other platforms are also supported; they use the Linux conventions.
 
-The minimal required version of Rust is 1.13.
+The minimal required version of Rust is 1.13 except for Redox, where the minimum Rust version
+depends on the [`redox_users`](https://crates.io/crates/redox_users) crate.
 
 It's mid-level sister library, _directories_, is available for Rust ([directories-rs](https://github.com/soc/directories-rs))
 and on the JVM ([directories-jvm](https://github.com/soc/directories-jvm)).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,26 +13,35 @@
 
 #![deny(missing_docs)]
 
-#[macro_use]
-extern crate cfg_if;
-
 use std::path::PathBuf;
 
-cfg_if! {
-    if #[cfg(target_os = "windows")] {
-        mod win;
-        use win as sys;
-    } else if #[cfg(any(target_os = "macos", target_os = "ios"))] {
-        mod mac;
-        use mac as sys;
-    } else if #[cfg(target_arch = "wasm32")] {
-        mod wasm;
-        use wasm as sys;
-    } else {
-        mod lin;
-        use lin as sys;
-    }
-}
+#[cfg(target_os = "windows")]
+mod win;
+#[cfg(target_os = "windows")]
+use win as sys;
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+mod mac;
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+use mac as sys;
+
+#[cfg(target_arch = "wasm32")]
+mod wasm;
+#[cfg(target_arch = "wasm32")]
+use wasm as sys;
+
+#[cfg(not(any(
+    target_os = "windows",
+    target_os = "macos", target_os = "ios",
+    target_arch = "wasm32"
+)))]
+mod lin;
+#[cfg(not(any(
+    target_os = "windows",
+    target_os = "macos", target_os = "ios",
+    target_arch = "wasm32"
+)))]
+use lin as sys;
 
 /// Returns the path to the user's home directory.
 ///


### PR DESCRIPTION
This is to allow the crate to compile with rustc 1.13.

The documentation is updated to indicate that a higher version of the compiler may be needed for Redox, since redox_users does not document a minimum rustc version.

This PR is the next step after https://github.com/soc/dirs-sys-rs/pull/5, and it needs a `dirs-sys` release 0.3.5 that includes that PR in order to work.

Fixes #25.