### PR TITLE
Fix typo in the test

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -317,8 +317,8 @@ mod tests {
         println!();
         println!("audio_dir:      {:?}", ::audio_dir());
         println!("desktop_dir:    {:?}", ::desktop_dir());
-        println!("cache_dir:      {:?}", ::document_dir());
-        println!("config_dir:     {:?}", ::download_dir());
+        println!("document_dir:   {:?}", ::document_dir());
+        println!("download_dir:   {:?}", ::download_dir());
         println!("font_dir:       {:?}", ::font_dir());
         println!("picture_dir:    {:?}", ::picture_dir());
         println!("public_dir:     {:?}", ::public_dir());


### PR DESCRIPTION
The item name was incorrect in the test.